### PR TITLE
Fix batch error parsing and return as result

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/reductstore/reduct-go/model"
 	"testing"
 	"time"
 
@@ -32,8 +33,9 @@ func TestBatchReading(t *testing.T) {
 	batch.Add(ts2, jsonData2, "application/json", map[string]any{"label2": "value2"})
 
 	// Write the batch
-	err = batch.Write(context.Background())
+	errMap, err := batch.Write(context.Background())
 	assert.NoError(t, err)
+	assert.Empty(t, errMap, "All records should be written successfully")
 
 	// Now test reading the batch
 	t.Run("read batch records", func(t *testing.T) {
@@ -89,8 +91,10 @@ func TestFetchAndParseBatchedRecords(t *testing.T) {
 
 	batch.Add(ts1, jsonData1, "application/json", map[string]any{"label1": "value1"})
 	batch.Add(ts2, jsonData2, "application/json", map[string]any{"label2": "value2"})
-	err = batch.Write(context.Background())
+	errMap, err := batch.Write(context.Background())
 	assert.NoError(t, err)
+	assert.Empty(t, errMap, "All records should be written successfully")
+
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	// get the id of the last record
@@ -128,8 +132,9 @@ func TestBatchWrite(t *testing.T) {
 	batch.Add(now+2, []byte("data3"), "text/plain", nil)
 
 	// Write batch
-	err := batch.Write(ctx)
+	errMap, err := batch.Write(ctx)
 	assert.NoError(t, err)
+	assert.Empty(t, errMap, "All records should be written successfully")
 
 	// Verify records
 	queryResult, err := mainTestBucket.Query(ctx, entry, nil)
@@ -157,14 +162,16 @@ func TestBatchUpdate(t *testing.T) {
 	now := time.Now().UTC().UnixMicro()
 	batch.Add(now, []byte("data1"), "text/plain", nil)
 	batch.Add(now+1, []byte("data2"), "text/plain", nil)
-	err := batch.Write(ctx)
+	errMap, err := batch.Write(ctx)
 	assert.NoError(t, err)
+	assert.Empty(t, errMap, "All records should be written successfully")
 
 	// Update labels
 	updateBatch := mainTestBucket.BeginUpdateBatch(ctx, entry)
 	updateBatch.AddOnlyLabels(now, map[string]any{"updated": "true"})
-	err = updateBatch.Write(ctx)
+	errMap, err = updateBatch.Write(ctx)
 	assert.NoError(t, err)
+	assert.Empty(t, errMap, "All records should be written successfully")
 
 	queryOptions := NewQueryOptionsBuilder().
 		WithStart(now).
@@ -189,12 +196,13 @@ func TestBatchRemove(t *testing.T) {
 	now := time.Now().UTC().UnixMicro()
 	batch.Add(now, []byte("data1"), "text/plain", nil)
 	batch.Add(now+1, []byte("data2"), "text/plain", nil)
-	err := batch.Write(ctx)
+	errMap, err := batch.Write(ctx)
 	assert.NoError(t, err)
+	assert.Empty(t, errMap, "All records should be written successfully")
 
 	// Remove records
 	removeBatch := mainTestBucket.BeginRemoveBatch(ctx, entry)
-	err = removeBatch.Write(ctx)
+	errMap, err = removeBatch.Write(ctx)
 	assert.NoError(t, err)
 
 	// Verify removal
@@ -219,13 +227,25 @@ func TestBatchErrors(t *testing.T) {
 
 	// Test empty batch
 	batch := mainTestBucket.BeginWriteBatch(ctx, entry)
-	err := batch.Write(ctx)
+	errMap, err := batch.Write(ctx)
 	assert.Error(t, err)
+	assert.Empty(t, errMap, "Empty batch should return an error but no error map")
 
 	// Test batch with invalid timestamps
 	batch = mainTestBucket.BeginWriteBatch(ctx, entry)
-	tm := -1
-	batch.Add(int64(tm), []byte("invalid"), "text/plain", nil)
-	err = batch.Write(ctx)
-	assert.Error(t, err)
+	tm := int64(1)
+	batch.Add(tm, []byte("new"), "text/plain", nil)
+	errMap, err = batch.Write(ctx)
+	assert.NoError(t, err)
+	assert.Empty(t, errMap, "All records should be written successfully")
+
+	batch.Clear()
+	batch.Add(tm, []byte("exists"), "text/plain", nil)
+	errMap, err = batch.Write(ctx)
+
+	assert.NoError(t, err)
+	assert.Equal(t, errMap[tm], model.APIError{
+		Status:  409,
+		Message: fmt.Sprintf("A record with timestamp %d already exists", tm),
+	})
 }

--- a/query_test.go
+++ b/query_test.go
@@ -20,8 +20,9 @@ func TestQuery(t *testing.T) {
 	batch.Add(now+1, []byte("data0"), "application/json", map[string]any{"type": "test0"})
 	batch.Add(now+2, []byte("data1"), "application/json", map[string]any{"type": "test1"})
 	batch.Add(now+3, []byte("data2"), "application/json", map[string]any{"type": "test2"})
-	err := batch.Write(ctx)
+	errMap, err := batch.Write(ctx)
 	assert.NoError(t, err)
+	assert.Empty(t, errMap, "All records should be written successfully")
 
 	t.Run("Query All Records", func(t *testing.T) {
 		queryResult, err := mainTestBucket.Query(ctx, entry, nil)
@@ -161,8 +162,9 @@ func TestQuery(t *testing.T) {
 		batch.Add(now+3, largeData, "application/octet-stream", map[string]any{"size": "large"})
 
 		// Write the batch
-		err := batch.Write(ctx)
+		errMap, err := batch.Write(ctx)
 		assert.NoError(t, err)
+		assert.Empty(t, errMap, "All records should be written successfully")
 
 		// Query and verify the records
 		queryResult, err := mainTestBucket.Query(ctx, entryLarge, nil)
@@ -213,8 +215,9 @@ func TestRemoveQuery(t *testing.T) {
 	batch.Add(now, []byte("data1"), "text/plain", map[string]any{"type": "test1"})
 	batch.Add(now+1, []byte("data2"), "text/plain", map[string]any{"type": "test2"})
 	batch.Add(now+1000, []byte("data3"), "text/plain", map[string]any{"type": "test3"})
-	err := batch.Write(ctx)
+	errMap, err := batch.Write(ctx)
 	assert.NoError(t, err)
+	assert.Empty(t, errMap, "All records should be written successfully")
 
 	t.Run("Remove by Time Range", func(t *testing.T) {
 		start := now
@@ -252,8 +255,9 @@ func TestRemoveQuery(t *testing.T) {
 		batch.Add(now, []byte("data3"), "text/plain", map[string]any{"type": "testExisting"})
 		batch.Add(now+1, []byte("data4"), "text/plain", map[string]any{"type": "testRemoved"})
 		batch.Add(now+2, []byte("data5"), "text/plain", map[string]any{"type": "testRemoved"})
-		err := batch.Write(ctx)
+		errMap, err := batch.Write(ctx)
 		assert.NoError(t, err)
+		assert.Empty(t, errMap, "All records should be written successfully")
 
 		options := &QueryOptions{
 			When: map[string]any{"&type": map[string]any{"$eq": "testRemoved"}},


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix/Feature

### What was changed?

Users need to check individual errors for batch requests. This PR fixes the parsing of errors and modifies the Batch.Writer method so that it returns a map of errors.


### Related issues

#17 

### Does this PR introduce a breaking change?

Yes, the API is changed but it's beta.

### Other information:
