### PR TITLE
Remove unnecessary WritableRecord.WithSize method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Breaking Changes
+
+* Remove unnecessary WritableRecord.WithSize method, [PR-29](https://github.com/reductstore/reduct-go/pull/29)
+
 ## 1.15.0-beta.5 - 2025-06-03
 
 ### Fixed

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -120,9 +120,10 @@ func TestUpdateRecordLabels(t *testing.T) {
 		Labels: LabelMap{
 			"initial": "value",
 		},
+		Size: int64(9),
 	})
 	reader := bytes.NewReader([]byte("test data"))
-	writer = writer.WithSize(9)
+
 	err := writer.Write(reader)
 	assert.NoError(t, err)
 

--- a/record.go
+++ b/record.go
@@ -24,11 +24,6 @@ type WritableRecord struct {
 	options    WriteOptions
 }
 
-func (w *WritableRecord) WithSize(size int64) *WritableRecord {
-	w.options.Size = size
-	return w
-}
-
 func NewWritableRecord(bucketName string,
 	entryName string,
 	httpClient httpclient.HTTPClient,


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Refactoring

### What was changed?

The PR removes WithSize method, because we can pass the size with timestamp.

### Related issues

#12 

### Does this PR introduce a breaking change?

Yes, but it's beta

### Other information:
