### PR TITLE
Remove deprecated fields from replication task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Breaking Changes
+
+* Remove deprecated `Include` and `Exclude` methods from `ReplicationSettings`, [PR-33](https://github.com/reductstore/reduct-go/pull/33)
+
 ## 1.15.0-beta.8 - 2025-06-05
 
 ### Added
 
-* * Missing methods  `RemoveEntry`, `RemoveRecord`, `RenamEntry`, [PR-32](https://github.com/reductstore/reduct-go/pull/32)
+* Missing methods  `RemoveEntry`, `RemoveRecord`, `RenamEntry`, [PR-32](https://github.com/reductstore/reduct-go/pull/32)
 
 ## 1.15.0-beta.7 - 2025-06-04
 

--- a/model/bucket.go
+++ b/model/bucket.go
@@ -5,7 +5,7 @@ package model
 
 import "encoding/json"
 
-// Represents bucket settings.
+// BucketSetting represents bucket settings.
 type BucketSetting struct {
 	// max block content_length in bytes
 	MaxBlockSize int64 `json:"max_block_size,omitempty"`
@@ -40,7 +40,7 @@ type BucketSettingBuilder struct {
 	bucket BucketSetting
 }
 
-// NewBucketSetting creates a new instance of BucketSettingBuilder with can be used to build a BucketSetting object.
+// NewBucketSettingBuilder creates a new instance of BucketSettingBuilder with can be used to build a BucketSetting object.
 func NewBucketSettingBuilder() *BucketSettingBuilder {
 	return &BucketSettingBuilder{}
 }
@@ -70,7 +70,7 @@ func (b *BucketSettingBuilder) WithQuotaType(qt QuotaType) *BucketSettingBuilder
 	return b
 }
 
-// Builds BucketSetting model.
+// Build Builds BucketSetting model.
 // Uses ["NONE"] QotaType if not set.
 func (b *BucketSettingBuilder) Build() BucketSetting {
 	if b.bucket.QuotaType == "" {
@@ -87,7 +87,7 @@ const (
 	QuotaTypeHard QuotaType = "HARD"
 )
 
-// Represents information about a bucket.
+// BucketInfo Represents information about a bucket.
 type BucketInfo struct {
 	// bucket name
 	Name string `json:"name"`
@@ -103,7 +103,7 @@ type BucketInfo struct {
 	IsProvisioned bool `json:"is_provisioned"`
 }
 
-// Information about the bucket in JSON format.
+// FullBucketDetail Information about the bucket in JSON format.
 type FullBucketDetail struct {
 	// bucket settings
 	Settings BucketSetting `json:"settings"`

--- a/model/replication.go
+++ b/model/replication.go
@@ -12,14 +12,6 @@ type ReplicationSettings struct {
 	DstToken string `json:"dst_token,omitempty"`
 	// List of entries to replicate. If empty, all entries are replicated. Wildcards are supported.
 	Entries []string `json:"entries,omitempty"`
-	// List of labels a records must include. If empty, all records are replicated.
-	// If a few labels are specified, a record must include all of them.
-	// Deprecated: use When instead
-	Include map[string]any `json:"include,omitempty"`
-	// List of labels a records must not include. If empty, all records are replicated.
-	// If a few labels are specified, a record must not include any of them.
-	// Deprecated: use When instead
-	Exclude map[string]any `json:"exclude,omitempty"`
 	// Replicate a record every S seconds
 	EachS int64 `json:"each_s,omitempty"`
 	// Replicate every Nth record


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Removal

### What was changed?

The PR removes depriecated Include/Exclude field from the `ReplicationSettings` struct.

### Related issues

#7 

### Does this PR introduce a breaking change?

Yes, but it's beta.

### Other information:
