### PR TITLE
chore(ci): enforce least-privilege GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
       - README.md
       - CHANGELOG.md
 
+permissions:
+  contents: read
+
 jobs:
   formatAndLint:
     runs-on: ubuntu-latest
@@ -92,6 +95,8 @@ jobs:
     needs: [run_tests, formatAndLint, check_tag]
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go


### PR DESCRIPTION
Closes #61

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Security hardening / CI configuration update.

### What was changed?

- Added a workflow-level default `permissions` block in `.github/workflows/ci.yml`:
  - `contents: read`
- Added a job-level override for the `publish` job:
  - `contents: write`
- Kept all non-release jobs on read-only token scope.

This implements the approved plan from issue #61 and narrows `GITHUB_TOKEN` permissions to least privilege by default.

### Related issues

- https://github.com/reductstore/reduct-go/issues/61
- Plan comment: https://github.com/reductstore/reduct-go/issues/61#issuecomment-4325085798
- Approval comment: https://github.com/reductstore/reduct-go/issues/61#issuecomment-4343643101

### Does this PR introduce a breaking change?

No.

### Other information:

Before/after permissions summary:
- Before: implicit default token permissions (broader than required).
- After: explicit repository-wide read-only default with scoped write access only for release publishing.