### PR TITLE
64 feat support non json content types in write attachmentsread attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Support non-JSON content types in `WriteAttachments` and `ReadAttachments`, [PR-65](https://github.com/reductstore/reduct-go/pull/65)
+
 ## 1.19.1 - 2026-04-22
 
 ### Fixed

--- a/bucket.go
+++ b/bucket.go
@@ -651,7 +651,7 @@ func (b *Bucket) WriteAttachments(ctx context.Context, entry string, attachments
 	if len(contentType) > 0 && contentType[0] != "" {
 		ct = contentType[0]
 	}
-	isJSON := isJsonContentType(ct)
+	isJSON := isJSONContentType(ct)
 
 	metaEntry := fmt.Sprintf("%s/$meta", entry)
 	ts := time.Now().UTC().UnixMicro()
@@ -729,7 +729,7 @@ func (b *Bucket) ReadAttachments(ctx context.Context, entry string) (map[string]
 		}
 
 		var payload any
-		if isJsonContentType(record.ContentType()) {
+		if isJSONContentType(record.ContentType()) {
 			if err := json.Unmarshal(content, &payload); err != nil {
 				return nil, fmt.Errorf("failed to decode attachment %q: %w", fmt.Sprint(key), err)
 			}
@@ -831,7 +831,7 @@ func firstRecordBatchError(errs RecordBatchErrorMap) error {
 	return nil
 }
 
-func isJsonContentType(contentType string) bool {
+func isJSONContentType(contentType string) bool {
 	ct := strings.TrimSpace(strings.SplitN(contentType, ";", 2)[0])
 	lower := strings.ToLower(ct)
 	return lower == "application/json" || lower == "text/json" || strings.HasSuffix(lower, "+json")

--- a/bucket.go
+++ b/bucket.go
@@ -2,6 +2,7 @@ package reductgo
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -638,7 +639,7 @@ func (b *Bucket) Update(ctx context.Context, entry string, ts int64, labels Labe
 //   - ctx: Context for cancellation and timeout control
 //   - entry: Name of the entry
 //   - attachments: Attachment key/value payloads
-func (b *Bucket) WriteAttachments(ctx context.Context, entry string, attachments map[string]any) error {
+func (b *Bucket) WriteAttachments(ctx context.Context, entry string, attachments map[string]any, contentType ...string) error {
 	if entry == "" {
 		return fmt.Errorf("entry name is required for attachments")
 	}
@@ -646,17 +647,36 @@ func (b *Bucket) WriteAttachments(ctx context.Context, entry string, attachments
 		return nil
 	}
 
+	ct := "application/json"
+	if len(contentType) > 0 && contentType[0] != "" {
+		ct = contentType[0]
+	}
+	isJSON := isJsonContentType(ct)
+
 	metaEntry := fmt.Sprintf("%s/$meta", entry)
 	ts := time.Now().UTC().UnixMicro()
 
 	batch := b.BeginWriteRecordBatch(ctx)
 	for key, payload := range attachments {
-		data, err := json.Marshal(payload)
-		if err != nil {
-			return fmt.Errorf("failed to marshal attachment %q: %w", key, err)
+		var data []byte
+		var err error
+		if isJSON {
+			data, err = json.Marshal(payload)
+			if err != nil {
+				return fmt.Errorf("failed to marshal attachment %q: %w", key, err)
+			}
+		} else {
+			b64, ok := payload.(string)
+			if !ok {
+				return fmt.Errorf("non-JSON attachment %q must be a base64-encoded string", key)
+			}
+			data, err = base64.StdEncoding.DecodeString(b64)
+			if err != nil {
+				return fmt.Errorf("failed to decode base64 for attachment %q: %w", key, err)
+			}
 		}
 
-		batch.Add(metaEntry, ts, data, "application/json", LabelMap{"key": key})
+		batch.Add(metaEntry, ts, data, ct, LabelMap{"key": key})
 		ts++
 	}
 
@@ -709,8 +729,12 @@ func (b *Bucket) ReadAttachments(ctx context.Context, entry string) (map[string]
 		}
 
 		var payload any
-		if err := json.Unmarshal(content, &payload); err != nil {
-			return nil, fmt.Errorf("failed to decode attachment %q: %w", fmt.Sprint(key), err)
+		if isJsonContentType(record.ContentType()) {
+			if err := json.Unmarshal(content, &payload); err != nil {
+				return nil, fmt.Errorf("failed to decode attachment %q: %w", fmt.Sprint(key), err)
+			}
+		} else {
+			payload = base64.StdEncoding.EncodeToString(content)
 		}
 
 		attachments[attachmentKey] = payload
@@ -805,6 +829,12 @@ func firstRecordBatchError(errs RecordBatchErrorMap) error {
 		}
 	}
 	return nil
+}
+
+func isJsonContentType(contentType string) bool {
+	ct := strings.TrimSpace(strings.SplitN(contentType, ";", 2)[0])
+	lower := strings.ToLower(ct)
+	return lower == "application/json" || lower == "text/json" || strings.HasSuffix(lower, "+json")
 }
 
 type QueryLinkOptions struct {

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -3,6 +3,7 @@ package reductgo
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -267,6 +268,44 @@ func TestRemoveAttachmentsWithNumericKeys(t *testing.T) {
 	attachments, err = mainTestBucket.ReadAttachments(ctx, entry)
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]any{}, attachments)
+}
+
+func TestWriteReadNonJsonAttachment(t *testing.T) {
+	ctx := context.Background()
+	skipVersingLower(ctx, t, "1.19.0")
+
+	entry := fmt.Sprintf("test-attachments-non-json-%d", time.Now().UTC().UnixNano())
+	rawBytes := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	encoded := base64.StdEncoding.EncodeToString(rawBytes)
+
+	err := mainTestBucket.WriteAttachments(ctx, entry, map[string]any{
+		"binary-data": encoded,
+	}, "application/octet-stream")
+	assert.NoError(t, err)
+
+	attachments, err := mainTestBucket.ReadAttachments(ctx, entry)
+	assert.NoError(t, err)
+	assert.Equal(t, encoded, attachments["binary-data"])
+}
+
+func TestWriteAttachmentsDefaultJson(t *testing.T) {
+	ctx := context.Background()
+	skipVersingLower(ctx, t, "1.19.0")
+
+	entry := fmt.Sprintf("test-attachments-default-json-%d", time.Now().UTC().UnixNano())
+	attachments := map[string]any{
+		"meta-1": map[string]any{
+			"enabled": true,
+			"values":  []any{"one", "two"},
+		},
+	}
+
+	err := mainTestBucket.WriteAttachments(ctx, entry, attachments)
+	assert.NoError(t, err)
+
+	readAttachments, err := mainTestBucket.ReadAttachments(ctx, entry)
+	assert.NoError(t, err)
+	assert.Equal(t, attachments, readAttachments)
 }
 
 func TestQueryLink(t *testing.T) {


### PR DESCRIPTION
Closes #64 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Format support

### What was changed?

Support non-JSON content types in `WriteAttachments` and `ReadAttachments`

### Related issues

No

### Does this PR introduce a breaking change?

Add optional `content type` to writeAttachments function

### Other information:
