### PR TITLE
ci: pin third-party GitHub Actions by commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           go-version: 1.24.2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa
         with:
           version: v2.0
           args: --timeout 5m --verbose
@@ -104,7 +104,7 @@ jobs:
         with:
           go-version: 1.24.2
       - name: Publish to GitHub Releases
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         with:
           files: |
             ./main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,12 @@ jobs:
   formatAndLint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: 1.24.2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
         with:
           version: v2.0
           args: --timeout 5m --verbose
@@ -45,7 +45,7 @@ jobs:
             features: "default"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Generate license
         run: echo '${{secrets.LICENSE_KEY}}' > lic.key
 
@@ -77,7 +77,7 @@ jobs:
     name: Check tag
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Check if tag matches version
         run: |
@@ -98,9 +98,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: 1.24.2
       - name: Publish to GitHub Releases

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           go-version: 1.24.2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: v2.2.2
           args: --timeout 5m --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
         with:
-          version: v2.1.0
+          version: v2.2.2
           args: --timeout 5m --verbose
 
   run_tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
         with:
-          version: v2.0
+          version: v2.1.0
           args: --timeout 5m --verbose
 
   run_tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support non-JSON content types in `WriteAttachments` and `ReadAttachments`, [PR-65](https://github.com/reductstore/reduct-go/pull/65)
 
+### Changed
+
+- Pin third-party GitHub Actions in CI workflows to immutable commit SHAs, [PR-66](https://github.com/reductstore/reduct-go/pull/66)
+
 ## 1.19.1 - 2026-04-22
 
 ### Fixed


### PR DESCRIPTION
Closes #63

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Security hardening / CI maintenance

### What was changed?

Pinned third-party GitHub Actions in `.github/workflows/ci.yml` from floating refs to immutable commit SHAs:

- `golangci/golangci-lint-action@v7` → `@9fae48acfc02a90574d7c304a1758ef9895495fa`
- `softprops/action-gh-release@v2` → `@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65`

First-party `actions/*` references were kept unchanged.

### Related issues

- https://github.com/reductstore/reduct-go/issues/63
- https://github.com/reductstore/security/issues/22
- Approved implementation plan: https://github.com/reductstore/reduct-go/issues/63#issuecomment-4396365842

### Does this PR introduce a breaking change?

No expected runtime breaking changes. This only affects CI workflow action resolution.

### Other information:

Local validation:
- `go build ./...` ✅
- `go vet ./...` ✅
- `gofmt -l .` ✅ (clean)
- `go test ./...` ⚠️ failed in integration setup because local ReductStore test server was unavailable (`localhost:8383` connection refused). CI will run full checks in GitHub Actions.
