### PR TITLE
Align lifecycle SDK with older_than and compress action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add lifecycle `compress` action support and rename lifecycle age field from `max_age` to `older_than` to match the ReductStore API, [PR-70](https://github.com/reductstore/reduct-go/pull/70)
+- Add lifecycle `compress` action support and rename lifecycle age field from `max_age` to `older_than` to match the ReductStore API, [PR-71](https://github.com/reductstore/reduct-go/pull/71)
 - Add lifecycle policy API support, [PR-69](https://github.com/reductstore/reduct-go/pull/69)
 
 ## [1.19.2] - 2026-05-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add lifecycle `compress` action support and rename lifecycle age field from `max_age` to `older_than` to match the ReductStore API, [PR-70](https://github.com/reductstore/reduct-go/pull/70)
 - Add lifecycle policy API support, [PR-69](https://github.com/reductstore/reduct-go/pull/69)
 
 ## [1.19.2] - 2026-05-16

--- a/client.go
+++ b/client.go
@@ -319,8 +319,8 @@ func validateLifecycle(name string, lifecycle model.LifecycleSettings, defaultMo
 	if lifecycle.Bucket == "" {
 		return lifecycle, fmt.Errorf("bucket is required")
 	}
-	if lifecycle.MaxAge == "" {
-		return lifecycle, fmt.Errorf("max_age is required")
+	if lifecycle.OlderThan == "" {
+		return lifecycle, fmt.Errorf("older_than is required")
 	}
 	if lifecycle.LifecycleType == "" {
 		lifecycle.LifecycleType = model.LifecycleTypeDelete

--- a/client_test.go
+++ b/client_test.go
@@ -519,10 +519,10 @@ func TestLifecycleAPI(t *testing.T) {
 
 	bucketName := getRandomBucketName()
 	lifecycle := model.LifecycleSettings{
-		LifecycleType: model.LifecycleTypeDelete,
+		LifecycleType: model.LifecycleTypeCompress,
 		Bucket:        bucketName,
 		Entries:       []string{},
-		MaxAge:        "1h",
+		OlderThan:     "1h",
 		Interval:      "10m",
 		Mode:          model.LifecycleModeEnabled,
 	}
@@ -546,7 +546,7 @@ func TestLifecycleAPI(t *testing.T) {
 	})
 
 	t.Run("UpdateLifecycle", func(t *testing.T) {
-		lifecycle.MaxAge = "2h"
+		lifecycle.OlderThan = "2h"
 		lifecycle.Interval = "20m"
 		err := client.UpdateLifecycle(ctx, "test-lifecycle", lifecycle)
 		assert.NoError(t, err)

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -4,13 +4,14 @@ package model
 type LifecycleType string
 
 const (
-	LifecycleTypeDelete LifecycleType = "delete"
+	LifecycleTypeDelete   LifecycleType = "delete"
+	LifecycleTypeCompress LifecycleType = "compress"
 )
 
 // IsValid returns true when the lifecycle type matches a known value.
 func (t LifecycleType) IsValid() bool {
 	switch t {
-	case LifecycleTypeDelete:
+	case LifecycleTypeDelete, LifecycleTypeCompress:
 		return true
 	default:
 		return false
@@ -44,8 +45,8 @@ type LifecycleSettings struct {
 	Bucket string `json:"bucket"`
 	// List of entries to process. If empty, all matching entries are used.
 	Entries []string `json:"entries,omitempty"`
-	// Maximum record age.
-	MaxAge string `json:"max_age"`
+	// Process records older than this duration.
+	OlderThan string `json:"older_than"`
 	// Interval between lifecycle runs.
 	Interval string `json:"interval,omitempty"`
 	// Conditional query.


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature update

### What was changed?

- add lifecycle `compress` action support to the Go SDK
- rename lifecycle settings field from `max_age` to `older_than`
- update lifecycle validation and integration tests to use the new field and action
- update changelog

### Related issues

- https://github.com/reductstore/reductstore/pull/1427
- https://github.com/reductstore/reductstore/pull/1429

### Does this PR introduce a breaking change?

Yes. The lifecycle API is still unreleased in this SDK, so it now uses `older_than` instead of `max_age` before release.

### Other information:

- `go test ./...` still expects a local ReductStore test server on `localhost:8383`; model/package tests pass but integration tests cannot run fully here without that server.
