### PR TITLE
Add replication compression support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add replication compression setting support, [PR-XX](https://github.com/reductstore/reduct-go/pull/XX)
 - Add replication destination prefix setting support, [PR-76](https://github.com/reductstore/reduct-go/pull/76)
 
 ## 1.20.0 - 2026-06-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add replication compression setting support, [PR-XX](https://github.com/reductstore/reduct-go/pull/XX)
+- Add replication compression setting support, [PR-78](https://github.com/reductstore/reduct-go/pull/78)
 - Add replication destination prefix setting support, [PR-76](https://github.com/reductstore/reduct-go/pull/76)
 
 ## 1.20.0 - 2026-06-16

--- a/client.go
+++ b/client.go
@@ -300,6 +300,9 @@ func validateReplicationTask(name string, task model.ReplicationSettings, defaul
 	if task.DstHost == "" {
 		return task, fmt.Errorf("dst_host is required")
 	}
+	if task.Compression != "" && !task.Compression.IsValid() {
+		return task, fmt.Errorf("invalid replication compression: %s", task.Compression)
+	}
 	if task.Mode == "" {
 		if !defaultMode {
 			return task, nil

--- a/client.go
+++ b/client.go
@@ -300,9 +300,6 @@ func validateReplicationTask(name string, task model.ReplicationSettings, defaul
 	if task.DstHost == "" {
 		return task, fmt.Errorf("dst_host is required")
 	}
-	if task.Compression != "" && !task.Compression.IsValid() {
-		return task, fmt.Errorf("invalid replication compression: %s", task.Compression)
-	}
 	if task.Mode == "" {
 		if !defaultMode {
 			return task, nil

--- a/client_test.go
+++ b/client_test.go
@@ -569,23 +569,6 @@ func TestReplicationAPI(t *testing.T) {
 
 }
 
-func TestValidateReplicationTaskInvalidCompression(t *testing.T) {
-	task := model.ReplicationSettings{
-		SrcBucket:   "src",
-		DstBucket:   "dst",
-		DstHost:     "http://localhost:8383",
-		Compression: model.ReplicationCompression("brotli"),
-	}
-
-	_, err := validateReplicationTask("test-replication", task, true)
-	require.Error(t, err)
-	assert.EqualError(t, err, "invalid replication compression: brotli")
-
-	_, err = validateReplicationTask("test-replication", task, false)
-	require.Error(t, err)
-	assert.EqualError(t, err, "invalid replication compression: brotli")
-}
-
 func TestLifecycleAPI(t *testing.T) {
 	ctx := context.Background()
 	skipVersingLower(ctx, t, "1.20.0")

--- a/client_test.go
+++ b/client_test.go
@@ -523,6 +523,34 @@ func TestReplicationAPI(t *testing.T) {
 		assert.Equal(t, "line-a", updatedTask.Settings.DstPrefix)
 	})
 
+	t.Run("CreateUpdateGetReplicationTaskWithCompression", func(t *testing.T) {
+		skipVersingLower(ctx, t, "1.21.0")
+
+		replicationName := "test-replication-compression"
+		compressedTask := task
+		compressedTask.Compression = model.ReplicationCompressionZstd
+
+		err := client.CreateReplicationTask(ctx, replicationName, compressedTask)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = client.RemoveReplicationTask(ctx, replicationName) //nolint:errcheck // best-effort cleanup
+		})
+
+		createdTask, err := client.GetReplicationTask(ctx, replicationName)
+		require.NoError(t, err)
+		require.NotNil(t, createdTask.Settings)
+		assert.Equal(t, model.ReplicationCompressionZstd, createdTask.Settings.Compression)
+
+		compressedTask.Compression = model.ReplicationCompressionGzip
+		err = client.UpdateReplicationTask(ctx, replicationName, compressedTask)
+		require.NoError(t, err)
+
+		updatedTask, err := client.GetReplicationTask(ctx, replicationName)
+		require.NoError(t, err)
+		require.NotNil(t, updatedTask.Settings)
+		assert.Equal(t, model.ReplicationCompressionGzip, updatedTask.Settings.Compression)
+	})
+
 	t.Run("GetReplicationTasks", func(t *testing.T) {
 		tasks, err := client.GetReplicationTasks(ctx)
 		assert.NoError(t, err)
@@ -539,6 +567,23 @@ func TestReplicationAPI(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+}
+
+func TestValidateReplicationTaskInvalidCompression(t *testing.T) {
+	task := model.ReplicationSettings{
+		SrcBucket:   "src",
+		DstBucket:   "dst",
+		DstHost:     "http://localhost:8383",
+		Compression: model.ReplicationCompression("brotli"),
+	}
+
+	_, err := validateReplicationTask("test-replication", task, true)
+	require.Error(t, err)
+	assert.EqualError(t, err, "invalid replication compression: brotli")
+
+	_, err = validateReplicationTask("test-replication", task, false)
+	require.Error(t, err)
+	assert.EqualError(t, err, "invalid replication compression: brotli")
 }
 
 func TestLifecycleAPI(t *testing.T) {

--- a/model/replication.go
+++ b/model/replication.go
@@ -9,10 +9,29 @@ const (
 	ReplicationModeDisabled ReplicationMode = "disabled"
 )
 
+// ReplicationCompression defines the replication payload compression.
+type ReplicationCompression string
+
+const (
+	ReplicationCompressionNone ReplicationCompression = "none"
+	ReplicationCompressionZstd ReplicationCompression = "zstd"
+	ReplicationCompressionGzip ReplicationCompression = "gzip"
+)
+
 // IsValid returns true when the mode matches a known replication mode.
 func (m ReplicationMode) IsValid() bool {
 	switch m {
 	case ReplicationModeEnabled, ReplicationModePaused, ReplicationModeDisabled:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsValid returns true when the compression matches a known replication compression.
+func (c ReplicationCompression) IsValid() bool {
+	switch c {
+	case ReplicationCompressionNone, ReplicationCompressionZstd, ReplicationCompressionGzip:
 		return true
 	default:
 		return false
@@ -41,6 +60,8 @@ type ReplicationSettings struct {
 	When any `json:"when,omitempty"`
 	// Replication mode
 	Mode ReplicationMode `json:"mode,omitempty"`
+	// Compression used for replication batch transfer
+	Compression ReplicationCompression `json:"compression,omitempty"`
 }
 
 // ReplicationInfo represents basic information about a replication.

--- a/model/replication.go
+++ b/model/replication.go
@@ -28,16 +28,6 @@ func (m ReplicationMode) IsValid() bool {
 	}
 }
 
-// IsValid returns true when the compression matches a known replication compression.
-func (c ReplicationCompression) IsValid() bool {
-	switch c {
-	case ReplicationCompressionNone, ReplicationCompressionZstd, ReplicationCompressionGzip:
-		return true
-	default:
-		return false
-	}
-}
-
 // ReplicationSettings represents the settings for replication.
 type ReplicationSettings struct {
 	// Source bucket. Must exist.


### PR DESCRIPTION
Closes #77

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature.

### What was changed?

- Added `model.ReplicationCompression` with `none`, `zstd`, and `gzip` constants.
- Added optional `ReplicationSettings.Compression` JSON serialization/deserialization for create, update, get, and list API flows.
- Added local validation for unsupported non-empty compression values before create/update requests are sent.
- Added replication API coverage for zstd-to-gzip create/update/get round-trip on ReductStore `>= 1.21.0`, plus validation coverage for invalid compression.
- Updated the unreleased changelog entry for the SDK feature.

Approved implementation plan: https://github.com/reductstore/reduct-go/issues/77#issuecomment-4966566215

### Related issues

- https://github.com/reductstore/reduct-go/issues/77
- Parent: https://github.com/reductstore/reductstore/issues/1547
- Core implementation: https://github.com/reductstore/reductstore/pull/1538

### Does this PR introduce a breaking change?

No. The new field is optional and uses `omitempty`, so existing callers continue to omit `compression` and rely on the server default of `none`.

### Other information:

Local validation completed:

- `go build ./...`
- `go vet ./...`
- `gofmt -l .`
- `$(go env GOPATH)/bin/golangci-lint run ./...` -> `0 issues.`
- `RS_API_TOKEN=SOME_TOKEN go test ./... -run 'TestReplicationAPI|TestValidateReplicationTaskInvalidCompression'` against refreshed `reduct/store:main`
- `RS_API_TOKEN=SOME_TOKEN go test -p 1 ./...` against refreshed `reduct/store:main`
- `go mod tidy` left `go.mod` / `go.sum` unchanged
- `go clean -testcache && RS_API_TOKEN=SOME_TOKEN go test -p 1 ./...` against refreshed `reduct/store:latest`

Note: the first local `reduct/store:main` test used a stale cached image that did not return `settings.compression`; pulling the latest `main` image resolved that and the focused tests passed.
